### PR TITLE
Optimize data fetching and SEO queries

### DIFF
--- a/src/app/[slug]/_components/Single-page-footer/RecommendationList.tsx
+++ b/src/app/[slug]/_components/Single-page-footer/RecommendationList.tsx
@@ -8,7 +8,7 @@ import Image from "next/image";
 interface Props { currentSlug: string }
 
 export default function RecommendationListMarquee({ currentSlug }: Props) {
-  const { posts } = useAppContext();
+  const { posts = [] } = useAppContext();
   const row1Ref = useRef<HTMLDivElement>(null);
   const row2Ref = useRef<HTMLDivElement>(null);
 

--- a/src/app/archive/page.tsx
+++ b/src/app/archive/page.tsx
@@ -15,7 +15,7 @@ function getFirstWords(htmlOrText: string, count: number) {
 }
 
 export default function PostsList() {
-  const { searchBarHeader, posts } = useAppContext();
+  const { searchBarHeader, posts = [] } = useAppContext();
   const term = searchBarHeader.trim().toLowerCase();
   const filtered = term
     ? posts.filter((p) => stripHtml(p.title).toLowerCase().includes(term))

--- a/src/app/category/[slug]/page.tsx
+++ b/src/app/category/[slug]/page.tsx
@@ -14,6 +14,7 @@ import Image from "next/image";
 import { ICategory, Post } from "@/lib/types";
 import type { Metadata } from "next";
 import { getBestSeoBySlug } from "@/lib/seo/seo-helpers";
+import { cache } from "react";
 import CategoryPosts from "./CategoryPosts";
 
 type Params = { slug: string };
@@ -28,11 +29,15 @@ function safeParse<T = unknown>(raw?: string): T | null {
   }
 }
 
+const getCategorySeo = cache(async (slug: string) => {
+  return getBestSeoBySlug(slug, "category");
+});
+
 export async function generateMetadata(
   { params }: { params: Promise<Params> }
 ): Promise<Metadata> {
   const { slug } = await params;
-  const { meta } = await getBestSeoBySlug(slug, "category");
+  const { meta } = await getCategorySeo(slug);
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const jsonLdRaw = (meta.other as any)?.jsonLd as string | undefined;
@@ -61,7 +66,7 @@ export default async function CategoryPage(
 
   if (!category) notFound();
 
-  const { meta: seoMeta } = await getBestSeoBySlug(slug, "category");
+  const { meta: seoMeta } = await getCategorySeo(slug);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const jsonLdRaw = (seoMeta.other as any)?.jsonLd as string | undefined;
   safeParse(jsonLdRaw);

--- a/src/app/category/route.ts
+++ b/src/app/category/route.ts
@@ -1,4 +1,4 @@
-import { getCategoryBySlug } from "@/lib/graph_queries/getCategory";
+import { getCategoryPosts } from "@/lib/graph_queries/getCategory";
 import { NextRequest, NextResponse } from "next/server";
 
 export async function GET(req: NextRequest) {
@@ -11,10 +11,10 @@ export async function GET(req: NextRequest) {
   }
 
   try {
-    const category = await getCategoryBySlug(slug, after);
+    const posts = await getCategoryPosts(slug, after);
     return NextResponse.json({
-      posts: category.posts.nodes,
-      pageInfo: category.posts.pageInfo,
+      posts: posts.nodes,
+      pageInfo: posts.pageInfo,
     });
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (err:any) {

--- a/src/app/components/Main-page/PostsList.tsx
+++ b/src/app/components/Main-page/PostsList.tsx
@@ -8,9 +8,10 @@ import { stripHtml } from '@/lib/helper_functions/strip_html';
 import { Sidebar } from './SideBar';
 import { Button } from '@/components/ui/button';
 import TradingViewWidget from '../tickers/uppcomingEventsTicker';
+import type { Post } from '@/lib/types';
 
-export default function PostsList() {
-  const { searchBarHeader, posts } = useAppContext();
+export default function PostsList({ posts }: { posts: Post[] }) {
+  const { searchBarHeader } = useAppContext();
   const term = searchBarHeader.trim().toLowerCase();
   const filtered = term
     ? posts.filter((p) => p.title.toLowerCase().includes(term))

--- a/src/app/components/Popular/PopularPosts.tsx
+++ b/src/app/components/Popular/PopularPosts.tsx
@@ -1,5 +1,5 @@
 // Serverkomponent (ingen 'use client')
-import { getPostByPeriod, getAllPosts } from '@/lib/graph_queries/getPost';
+import { getPostByPeriod } from '@/lib/graph_queries/getPost';
 import PopularNews from './PopularPostsGrid';
 import { Post } from '@/lib/types';
 import { getSiteTagline } from '@/lib/graph_queries/getSiteTagline';
@@ -42,7 +42,7 @@ function appendWithoutDupes(base: Post[], extra: Post[], seen: Set<string>): Pos
   return out;
 }
 
-export default async function PopularPosts() {
+export default async function PopularPosts({ posts = [] }: { posts?: Post[] }) {
   const taglinePromise = getSiteTagline();
 
   // 1) Week
@@ -56,10 +56,9 @@ export default async function PopularPosts() {
     merged = appendWithoutDupes(merged, month, seen);
   }
 
-  // 3) Top up from Latest (guaranteed to have posts)
-  if (merged.length < 9) {
-    const latest = (await getAllPosts()) ?? [];
-    merged = appendWithoutDupes(merged, latest, seen);
+  // 3) Top up from Latest (using existing posts)
+  if (merged.length < 9 && posts.length > 0) {
+    merged = appendWithoutDupes(merged, posts, seen);
   }
 
   const tagline = await taglinePromise;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,7 +7,6 @@ import "@/styles/globals.css";
 
 import { AppProvider } from "@/store/AppContext";
 import { getLogo } from "@/lib/graph_queries/getLogo";
-import { getAllPosts } from "@/lib/graph_queries/getPost";
 import { getTagLine } from "@/lib/graph_queries/getTagline";
 
 import HeaderServer from "./components/Main-page/HeaderServer";
@@ -36,9 +35,8 @@ interface RootLayoutProps {
 }
 
 export default async function RootLayout({ children }: RootLayoutProps) {
-  const [favicon, posts, tagline] = await Promise.all([
+  const [favicon, tagline] = await Promise.all([
     getLogo().catch(() => null),
-    getAllPosts(),
     getTagLine(),
   ]);
 
@@ -55,7 +53,7 @@ export default async function RootLayout({ children }: RootLayoutProps) {
         />
       </head>
       <body className="flex min-h-screen flex-col">
-        <AppProvider logo={favicon} posts={posts} tagline={tagline}>
+        <AppProvider logo={favicon} tagline={tagline}>
           <HeaderServer />
           <main className="flex-1">{children}</main>
           <Footer />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,7 @@ import PopularPosts from './components/Popular/PopularPosts';
 import CatsPage from './[slug]/_components/categoryWrapper';
 import TradingViewScreener from './components/tickers/TradingViewScreener';
 import FinanstidningSeoText from './seoTextMainPage';
+import { getAllPosts } from '@/lib/graph_queries/getPost';
 // import AdsSection from './components/ads/AdsSection';
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -36,16 +37,17 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function Page() {
+  const posts = await getAllPosts();
   return (
     <div>
       {/* <AdsSection /> */}
-      <PopularPosts />
+      <PopularPosts posts={posts} />
       {/* <AdsSection /> */}
       <TradingViewScreener />
       {/* <AdsSection /> */}
       <CatsPage />
       {/* <AdsSection /> */}
-      <PostsList />
+      <PostsList posts={posts} />
       {/* <AdsSection /> */}
       <FinanstidningSeoText />
       {/* <AdPopup /> */}

--- a/src/app/tag/route.ts
+++ b/src/app/tag/route.ts
@@ -1,4 +1,4 @@
-import { getTagBySlug } from "@/lib/graph_queries/getTag";
+import { getTagPosts } from "@/lib/graph_queries/getTag";
 import { NextRequest, NextResponse } from "next/server";
 
 export async function GET(req: NextRequest) {
@@ -11,10 +11,10 @@ export async function GET(req: NextRequest) {
   }
 
   try {
-    const tag = await getTagBySlug(slug, after);
+    const posts = await getTagPosts(slug, after);
     return NextResponse.json({
-      posts: tag.posts.nodes,
-      pageInfo: tag.posts.pageInfo,
+      posts: posts.nodes,
+      pageInfo: posts.pageInfo,
     });
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (err: any) {

--- a/src/lib/graph_queries/getTag.ts
+++ b/src/lib/graph_queries/getTag.ts
@@ -116,5 +116,68 @@ export async function getTagBySlug(slug: string, after?: string) {
   }
 }
 
+export async function getTagPosts(slug: string, after?: string) {
+  const query = `
+    query TagPosts($slug: ID!, $after: String) {
+      tag(id: $slug, idType: SLUG) {
+        posts(first: 6, after: $after) {
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+          nodes {
+            id
+            title
+            slug
+            excerpt
+            date
+            featuredImage {
+              node {
+                sourceUrl
+                altText
+              }
+            }
+            author {
+              node {
+                id
+                name
+                slug
+                avatar {
+                  url
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `;
+
+  try {
+    const res = await signedFetch(process.env.WP_GRAPHQL_URL!, {
+      method: 'POST',
+      json: { query, variables: { slug, after } },
+      next: { revalidate: 3600, tags: [`tag-${slug}`] },
+    });
+    if (!res.ok) {
+      throw new Error(`Network response was not ok: ${res.statusText}`);
+    }
+
+    const json = await res.json();
+
+    if (json.errors) {
+      console.error('GraphQL errors:', json.errors);
+      throw new Error(json.errors[0]?.message || 'GraphQL error');
+    }
+
+    const posts = json.data?.tag?.posts;
+    if (!posts) return { nodes: [], pageInfo: { hasNextPage: false, endCursor: '' } };
+    return posts;
+  } catch (error) {
+    console.error('Error fetching tag posts:', error);
+    throw new Error('Failed to fetch tag posts');
+  }
+}
+
 
 

--- a/src/store/AppContext.tsx
+++ b/src/store/AppContext.tsx
@@ -32,7 +32,7 @@ export const DEFAULT_LINKS = [
 export interface AppContextType {
   links: LinkItem[];
   logo: Logo | null;
-  posts: Post[];
+  posts?: Post[];
   searchBarHeader: string;
   setSearchBarHeader: Dispatch<SetStateAction<string>>;
   tagline: string;
@@ -51,7 +51,7 @@ export interface AppProviderProps {
   children: ReactNode;
   links?: LinkItem[];
   logo?: Logo | null;
-  posts: Post[];
+  posts?: Post[];
   tagline?: string;
 }
 
@@ -59,7 +59,7 @@ export const AppProvider: React.FC<AppProviderProps> = ({
   children,
   links = DEFAULT_LINKS,
   logo = null,
-  posts,
+  posts = [],
   tagline = '',
 }) => {
   const [searchBarHeader, setSearchBarHeader] = useState('');


### PR DESCRIPTION
## Summary
- fetch posts only on pages that need them and reuse in PopularPosts
- avoid duplicate SEO lookups on tag and category pages using a cache
- add lightweight tag and category post queries for infinite scroll APIs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find module '@next/bundle-analyzer')*
- `npm run build` *(fails: Cannot find module '@next/bundle-analyzer')*

------
https://chatgpt.com/codex/tasks/task_b_68b2fe4ea9d88322b951669afa206438